### PR TITLE
Add Taurine / libkernrw support (also only build as arm64)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: all macos clean
 
 all:
-	xcrun -sdk iphoneos clang -arch arm64 -arch arm64e -mios-version-min=10.0 -Weverything libdimentio.c dimentio.c -o dimentio -framework IOKit -framework CoreFoundation -lcompression -O2
+	xcrun -sdk iphoneos clang -arch arm64 -mios-version-min=10.0 -Weverything libdimentio.c dimentio.c -o dimentio -framework IOKit -framework CoreFoundation -lcompression -O2
 
 macos:
 	xcrun -sdk macosx clang -arch arm64 -Weverything libdimentio.c dimentio.c -o dimentio -framework IOKit -framework CoreFoundation -lcompression -O2


### PR DESCRIPTION
The upcoming Taurine jailbreak uses libKernRW to facilitate kernel read/write
* libKernRW is only built as an arm64 slice (tweaks shouldn't use it, and it requires being root anyways)
* Command line utilities in general should only be built for arm64, due to ABI differences with arm64e between iOS 13 & 14
* Use sysctl to check for arm64e when dimentio is built for arm64
* Don't rely on xpacd as it's being built as arm64
* libKernRW requires requesting for permission to use kernel read/write. This is required as libkernrw requires initialization + potentially requesting user permission for kernel read/write 

Current Limitations
* Nonce currently can't be set as kernRW_writebuf isn't implemented yet (though this will be resolved with a libkernrw update as the underlying kernRW_write32 / kernRW_write64 primitives are implemented already). Reading works perfectly though

Header file for libKernRW: https://gist.github.com/coolstar/cde7bfe010373e47a527ad10991c6cfa 