### PR TITLE
Print key.val with correct endianess

### DIFF
--- a/libdimentio.c
+++ b/libdimentio.c
@@ -23,6 +23,7 @@
 #include <sys/stat.h>
 #include <sys/sysctl.h>
 #include <sys/utsname.h>
+#include <libkern/OSByteOrder.h>
 
 #define LZSS_F (18)
 #define LZSS_N (4096)
@@ -1051,7 +1052,7 @@ hash_nonce(uint64_t nonce, uint8_t nonce_d[CC_SHA384_DIGEST_LENGTH]) {
 								if(kread_buf(aes_object + IO_AES_ACCELERATOR_SPECIAL_KEY_CNT_OFF, &key_cnt, sizeof(key_cnt)) == KERN_SUCCESS) {
 									printf("key_cnt: 0x%" PRIX32 "\n", key_cnt);
 									while(key_cnt-- != 0 && kread_buf(keys_ptr + key_cnt * sizeof(key), &key, sizeof(key)) == KERN_SUCCESS) {
-										printf("generated: 0x%" PRIX32 ", key_id: 0x%" PRIX32 ", key_sz: 0x%" PRIX32 ", val: 0x%08" PRIX32 "%08" PRIX32 "%08" PRIX32 "%08" PRIX32 "\n", key.generated, key.key_id, key.key_sz, key.val[0], key.val[1], key.val[2], key.val[3]);
+										printf("generated: 0x%" PRIX32 ", key_id: 0x%" PRIX32 ", key_sz: 0x%" PRIX32 ", val: 0x%08" PRIX32 "%08" PRIX32 "%08" PRIX32 "%08" PRIX32 "\n", key.generated, key.key_id, key.key_sz, OSSwapInt32(key.val[0]), OSSwapInt32(key.val[1]), OSSwapInt32(key.val[2]), OSSwapInt32(key.val[3]));
 										if(key.generated == 1 && key.key_id == 0x8A3 && key.key_sz == 8 * kCCKeySizeAES128) {
 											if(CCCrypt(kCCEncrypt, kCCAlgorithmAES128, 0, key.val, kCCKeySizeAES128, NULL, buf, sizeof(buf), buf, sizeof(buf), &out_sz) == kCCSuccess && out_sz == sizeof(buf)) {
 												CC_SHA384(buf, sizeof(buf), nonce_d);


### PR DESCRIPTION
Print key.val with correct endianess via OSSwapInt32.